### PR TITLE
fix: prevent a user from seeing privileged UI

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,6 +11,10 @@ rules:
     off
   react/prop-types:
     off
+  jsx-a11y/click-events-have-key-events:
+    off
+  jsx-a11y/no-static-element-interactions:
+    off
 globals:
   document: false
   window: false

--- a/client/src/components/buttons/FriendButton.jsx
+++ b/client/src/components/buttons/FriendButton.jsx
@@ -53,7 +53,7 @@ class FriendButton extends Component {
 
     return (
       <div>
-        <button type="button" onClick={() => this.handleFriendButton()}>{action}</button>
+        <button className="btn btn-outline-primary" type="button" onClick={() => this.handleFriendButton()}>{action}</button>
       </div>
     );
   }

--- a/client/src/components/rap-post/RapPostEntry.jsx
+++ b/client/src/components/rap-post/RapPostEntry.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import axios from 'axios';
+import { Link } from 'react-router-dom';
 import Comments from './comments';
 import Alert from '../alert';
-import { Link } from 'react-router-dom';
 import './rapPost.css';
 
 class RapPostEntry extends React.Component {
@@ -36,7 +36,7 @@ class RapPostEntry extends React.Component {
 
   likeRapPost = async () => {
     try {
-      const status = await axios.put(
+      await axios.put(
         '/api/vote/upvote',
         { rapPostId: this.props.rapPost.id },
       );
@@ -55,7 +55,7 @@ class RapPostEntry extends React.Component {
 
   reportPost = async () => {
     try {
-      const status = await axios.post(
+      await axios.post(
         '/api/content/report',
         { rapPostId: this.props.rapPost.id },
       );
@@ -105,12 +105,12 @@ class RapPostEntry extends React.Component {
       <div className="col-md-6">
         <div className="card">
           <div className="card-body">
-            {this.state.alert ? <Alert message={this.state.alertMessage} status={this.state.alertStatus} /> : null}
+            {this.state.alert ? <Alert message={this.state.alertMessage} status={this.state.alertStatus} /> : null} {/* eslint-disable-line*/}
             <p><button className="btn btn-primary" onClick={() => this.likeRapPost()}>Like <span className="badge badge-light">{this.state.likes}</span></button></p>
             <button className="badge badge-warning" onClick={() => this.reportPost()}>Report Post</button>
             <h5 className="card-title">
               By{' '}
-              <Link to={{ pathname: '/profile', state: { username }}}>{username}</Link>
+              <Link to={{ pathname: '/profile', state: { username }}}>{username}</Link> {/* eslint-disable-line */}
             </h5>
             <div className="rapText">
               <p className="card-text">{this.props.rapPost.text.split('\n').map(line => <div className="rap-text">{line}</div>)}</p>

--- a/client/src/components/user/Bio.jsx
+++ b/client/src/components/user/Bio.jsx
@@ -51,18 +51,21 @@ class Bio extends React.Component {
   render() {
     return (
       <div className="row">
-        About Me
-        {(!this.state.bio || this.state.showEdit) && (
-          <div className="row">
-            <textarea
-              name="input"
-              rows="3"
-              maxLength="250"
-              placeholder="Write your bio here (max 250 characters)"
-              onChange={e => this.onChange(e)}
-            />
-            <button className="btn btn-outline-primary" onClick={() => this.addBio()}>Submit</button>
-          </div>)}
+        <label htmlFor="bioedit">About Me{' ' /* eslint-disable-line */ }
+          {(this.state.user === this.props.username) &&
+            ((!this.state.bio || this.state.showEdit) && (
+            <div id="bioedit" className="row" style={{ margin: '10px' }}>
+              <textarea
+                className="form-control"
+                name="input"
+                rows="3"
+                maxLength="250"
+                placeholder="Write your bio here (max 250 characters)"
+                onChange={e => this.onChange(e)}
+              />
+              <button className="btn btn-outline-primary" onClick={() => this.addBio()}>Submit</button>
+            </div>))}
+        </label>
         {(this.state.bio || this.state.showBio) && (<div className="row">{this.state.bio}</div>)}<br /><br />
         {this.state.user === this.props.username ? <button className="btn btn-outline-primary" onClick={e => this.editBio(e)}>Edit Bio</button> : null}
       </div>

--- a/client/src/components/user/Bio.jsx
+++ b/client/src/components/user/Bio.jsx
@@ -3,7 +3,6 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import store from '../../redux/store';
 
-
 class Bio extends React.Component {
   constructor(props) {
     super(props);
@@ -57,6 +56,7 @@ class Bio extends React.Component {
             <div id="bioedit" className="row" style={{ margin: '10px' }}>
               <textarea
                 className="form-control"
+                style={{ margin: '10px' }}
                 name="input"
                 rows="3"
                 maxLength="250"
@@ -67,7 +67,7 @@ class Bio extends React.Component {
             </div>))}
         </label>
         {(this.state.bio || this.state.showBio) && (<div className="row">{this.state.bio}</div>)}<br /><br />
-        {this.state.user === this.props.username ? <button className="btn btn-outline-primary" onClick={e => this.editBio(e)}>Edit Bio</button> : null}
+        {this.state.user === this.props.username && this.state.bio ? <button className="btn btn-outline-primary" onClick={e => this.editBio(e)}>Edit Bio</button> : null}
       </div>
     );
   }

--- a/client/src/components/user/Bio.jsx
+++ b/client/src/components/user/Bio.jsx
@@ -14,7 +14,7 @@ class Bio extends React.Component {
   }
 
   componentDidMount() {
-    this.setState({
+    this.setState({ // eslint-disable-line
       bio: this.props.bio,
       showBio: true,
       showButton: true,
@@ -29,7 +29,7 @@ class Bio extends React.Component {
   }
 
   addBio = async () => {
-    const status = await axios.put(
+    await axios.put(
       'api/profile/bio',
       { bio: this.state.input },
     );
@@ -72,7 +72,6 @@ class Bio extends React.Component {
 
 Bio.propTypes = {
   bio: PropTypes.string.isRequired,
-  status: PropTypes.string.isRequired,
   username: PropTypes.string.isRequired,
 };
 

--- a/client/src/components/user/Profile.jsx
+++ b/client/src/components/user/Profile.jsx
@@ -6,11 +6,12 @@ import ProfileImage from './ProfileImage';
 import Bio from './Bio';
 import FriendButton from '../buttons/FriendButton';
 
+import store from '../../redux/store';
+
 class Profile extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      currUser: '',
       userPosts: [],
       username: '',
       likeCount: '',
@@ -19,6 +20,7 @@ class Profile extends React.Component {
       received: false,
     };
   }
+
   componentWillMount() {
     if (this.props.location.state) {
       const { username } = this.props.location.state;
@@ -28,6 +30,13 @@ class Profile extends React.Component {
       this.getUserData();
       this.getUserPosts();
     }
+  }
+
+  componentDidMount() {
+    this.setState(store.getState());  // eslint-disable-line
+    store.subscribe(() => {
+      this.setState(store.getState());
+    });
   }
 
   getUserData = async (username) => {
@@ -62,14 +71,18 @@ class Profile extends React.Component {
     return (
       <div>
         <div className="row">
-          {this.state.received && <ProfileImage image={this.state.image} />}
+          {this.state.received && <ProfileImage image={this.state.image} user={state ? state.username : this.state.user} /> /* eslint-disable-line */ }
           <div className="col-md-6">
             <Stats username={this.state.username} likeCount={this.state.likeCount} />
             {this.state.received && <Bio username={this.state.username} bio={this.state.bio} />}
           </div>
         </div>
-        {state && <FriendButton username={state.username} />}
-        <UserPosts userPosts={this.state.userPosts} getUserPosts={this.getUserPosts} getUserData={this.getUserData} />
+        <div className="row">
+          <div className="col-md-4">
+            {state && state.username !== this.state.user && <FriendButton className="btn btn-outline-primary" username={state.username} />}
+          </div>
+        </div>
+        <UserPosts userPosts={this.state.userPosts} getUserPosts={this.getUserPosts} getUserData={this.getUserData} /> {/* eslint-disable-line */}
       </div>
     );
   }

--- a/client/src/components/user/Profile.jsx
+++ b/client/src/components/user/Profile.jsx
@@ -79,7 +79,7 @@ class Profile extends React.Component {
         </div>
         <div className="row">
           <div className="col-md-4">
-            {state && state.username !== this.state.user && <FriendButton className="btn btn-outline-primary" username={state.username} />}
+            {state && state.username !== this.state.user && <FriendButton username={state.username} /> /* eslint-disable-line */ }
           </div>
         </div>
         <UserPosts userPosts={this.state.userPosts} getUserPosts={this.getUserPosts} getUserData={this.getUserData} /> {/* eslint-disable-line */}

--- a/client/src/components/user/ProfileImage.jsx
+++ b/client/src/components/user/ProfileImage.jsx
@@ -65,7 +65,7 @@ class ProfileImage extends React.Component {
   render() {
     return (
       <div className="col-2">
-        {(this.props.user !== this.state.user)
+        {(this.props.user === this.state.user)
           && ((!this.state.image || this.state.showChangePic)
           && (
           <Dropzone
@@ -77,10 +77,11 @@ class ProfileImage extends React.Component {
           </Dropzone>))}
         {(this.state.image && !this.state.showChangePic) && (
         <div className="container-img">
-          <img src={this.state.image} alt="ProfilePic" className="image-prof" />
-          <div className="middle">
-            <div className="text" onClick={() => this.editPic()}>Change Picture</div>
-          </div>
+          <img src={this.state.image} style={{ margin: '10px' }} alt="ProfilePic" className="image-prof" />
+          {this.props.user === this.state.user &&
+            <div className="middle">
+              <div className="text" onClick={() => this.editPic()}>Change Picture</div>
+            </div>}
         </div>
         )}
       </div>

--- a/client/src/components/user/ProfileImage.jsx
+++ b/client/src/components/user/ProfileImage.jsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import API_KEY from './config';
 import './profile.css';
 
+import store from '../../redux/store';
 
 class ProfileImage extends React.Component {
   constructor(props) {
@@ -11,13 +12,19 @@ class ProfileImage extends React.Component {
     this.state = {
       image: '',
       showChangePic: false,
-      user: '',
     };
   }
 
   componentWillMount() {
     this.setState({
       image: this.props.image,
+    });
+  }
+
+  componentDidMount() {
+    this.setState(store.getState()); // eslint-disable-line
+    store.subscribe(() => {
+      this.setState(store.getState());
     });
   }
 
@@ -29,7 +36,7 @@ class ProfileImage extends React.Component {
 
   handleDrop = (files) => {
     const uploaders = files.map((file) => {
-      const formData = new FormData();
+      const formData = new FormData(); // eslint-disable-line
       formData.append('file', file);
       formData.append('upload_preset', 'hkhkmnpg');
       formData.append('api_key', API_KEY);
@@ -38,7 +45,7 @@ class ProfileImage extends React.Component {
       return axios.post('https://api.cloudinary.com/v1_1/dkwbeount/image/upload', formData, {
         headers: { 'X-Requested-With': 'XMLHttpRequest' },
       }).then((response) => {
-        const data = response.data;
+        const { data } = response;
         const fileURL = data.secure_url;
         axios.put('api/profile/image', { image: fileURL });
         this.setState({
@@ -58,13 +65,16 @@ class ProfileImage extends React.Component {
   render() {
     return (
       <div className="col-2">
-        {(!this.state.image || this.state.showChangePic) && (<Dropzone
-          onDrop={this.handleDrop}
-          multiple
-          accept="image/*"
-        >
-          <p>Drop files or click to upload your profile pic</p>
-        </Dropzone>)}
+        {(this.props.user !== this.state.user)
+          && ((!this.state.image || this.state.showChangePic)
+          && (
+          <Dropzone
+            onDrop={this.handleDrop}
+            multiple
+            accept="image/*"
+          >
+            <p>Drop files or click to upload your profile pic</p>
+          </Dropzone>))}
         {(this.state.image && !this.state.showChangePic) && (
         <div className="container-img">
           <img src={this.state.image} alt="ProfilePic" className="image-prof" />


### PR DESCRIPTION
User could see edit buttons for profiles photos and bios of other users.

There are still other glitches: clicking profile again in the navbar (while viewing another user's profile) will remove the "friend/unfriend" button since that context is passed down from props. This means that we'll be viewing another person's information without the option of friending or unfriending them. State is lost or something. In another words, the "friend/unfriend" option is entirely dependent on our having visited that user's profile from the Top/New feed. But on revisiting from our current location...