### PR TITLE
See description

### DIFF
--- a/client/src/components/home/index.jsx
+++ b/client/src/components/home/index.jsx
@@ -166,7 +166,7 @@ class Home extends React.Component {
         <div className="row">
           <div className="col-md-6" style={{ margin: '5px' }}>
             {this.state.session ?
-             'To indicate an internal rhyme, use a comma, to indicate an end rhyme, start a new line. Please avoid the use of punctuation.' /* eslint-disable-line */
+             'To indicate an internal rhyme, use a comma, to indicate an end rhyme, start a new line. Please avoid the use of unnecessary punctuation or spacing.' /* eslint-disable-line */
              : 'Perhaps you\'d like to sign up...'}
           </div>
         </div>

--- a/client/src/components/home/index.jsx
+++ b/client/src/components/home/index.jsx
@@ -70,7 +70,7 @@ class Home extends React.Component {
     if (!this.state.lastHit) {
       this.setState({ lastHit: new Date() });
     } else if ((new Date()) - this.state.lastHit < 10000) {
-      alert('Only one API request every 10 seconds.');
+      alert('Only one API request every 10 seconds.'); // eslint-disable-line
       return;
     } else {
       this.setState({ lastHit: new Date() });

--- a/client/src/components/textarea/Textarea.jsx
+++ b/client/src/components/textarea/Textarea.jsx
@@ -23,16 +23,29 @@ const changeHandler = (e) => {
   // localStorage.setItem(user, JSON.stringify(browser));
 };
 
-const Textarea = () => (
-  <textarea
-    className="col form-control"
-    id="lyrics"
-    style={style}
-    onChange={changeHandler}
-    placeholder="Lyrics..."
-    cols="30"
-    rows="5"
-  />
-);
+class Textarea extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = store.getState();
+    store.subscribe(() => {
+      this.setState(store.getState());
+    });
+  }
+
+  render() {
+    return (
+      <textarea
+        className="col form-control"
+        id="lyrics"
+        style={style}
+        onChange={changeHandler}
+        placeholder="Lyrics..."
+        value={this.state.text}
+        cols="30"
+        rows="5"
+      />
+    );
+  }
+}
 
 export default Textarea;

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -7,20 +7,20 @@ const DEFAULT = {
   session: false,
   text: `C.L. Smooth:
 
-  Circulate us in the vein, set to ride the cracks on your brain
-  Like a novocaine, I train, to ease any pain
-  Yeah, get your wig loose, I relieve tension
-  The path to my lesson, is the highway to heaven
-  Plus, what a rush, catch another one flush
-  Now you got a crush, making dames wanna blush
-  I stomp out your campfire, liar, retire
+Circulate us in the vein, set to ride the cracks on your brain
+Like a novocaine, I train, to ease any pain
+Yeah, get your wig loose, I relieve tension
+The path to my lesson, is the highway to heaven
+Plus, what a rush, catch another one flush
+Now you got a crush, making dames wanna blush
+I stomp out your campfire, liar, retire
 
-  Example:
+Example:
 
-  HRLA twenty, gave me plenty, of stuff to learn
-  I spurn, heavy, messy, lyrics, template strings and back ticks
-  My rhymes are so sick, I'm like John Wick, ladle the sauce, extra thick
-  These words will stick, colorful lyrics, I used the same word, like Nick`,
+HRLA twenty, gave me plenty, of stuff to learn
+I spurn, heavy, messy, lyrics, template strings and back ticks
+My rhymes are so sick, I'm like John Wick, ladle the sauce, extra thick
+These words will stick, colorful lyrics, I used the same word, like Nick`,
   strictness: 'Strict',
   color: 'red',
 };

--- a/rhyme-engine/src/index.js
+++ b/rhyme-engine/src/index.js
@@ -31,7 +31,7 @@ app.post('/parse', async (req, res) => {
     options.weight = 3;
     options.length = 2;
   } else if (strictness === 'Loose') {
-    options.weight = 3;
+    options.weight = 1;
     options.length = 1;
   }
   console.log('REQUEST:', req.body);

--- a/rhyme-engine/src/parse.js
+++ b/rhyme-engine/src/parse.js
@@ -72,11 +72,9 @@ const parse = (text, options) =>
     words.forEach((word) => {
       if (typeof word === 'string') {
         const normalized = word.replace(/[,.:;'"“”‘’()&?-]/g, ''); // Hyphen either at the beginning or end, or escaped, i.e. \-
-        // console.log(normalized);
         APIcalls.push(API(normalized));
       } else {
         APIcalls.push(new Promise((resolution) => {
-          // console.log(word);
           resolution(word);
         }));
       }

--- a/rhyme-engine/src/parse.js
+++ b/rhyme-engine/src/parse.js
@@ -72,11 +72,11 @@ const parse = (text, options) =>
     words.forEach((word) => {
       if (typeof word === 'string') {
         const normalized = word.replace(/[,.:;'"“”‘’()&?-]/g, ''); // Hyphen either at the beginning or end, or escaped, i.e. \-
-        console.log(normalized);
+        // console.log(normalized);
         APIcalls.push(API(normalized));
       } else {
         APIcalls.push(new Promise((resolution) => {
-          console.log(word);
+          // console.log(word);
           resolution(word);
         }));
       }

--- a/rhyme-engine/src/parse.js
+++ b/rhyme-engine/src/parse.js
@@ -67,14 +67,16 @@ const parse = (text, options) =>
       });
       colors.push(null);
       coords.push('derp'); // Not a colorable coordinate. 'words' must be kept in step with 'colors' and 'coords'.
-      words.push({ x, message: '<LINEBREAK>' });
+      words.push({ x, message: '<LINEBREAK>', pronunciation: false });
     });
     words.forEach((word) => {
       if (typeof word === 'string') {
-        const normalized = word.replace(/[,.:;'"“”‘’()&?-]/g, ''); // Hypen either at the beginning or end, or escaped, i.e. \-
+        const normalized = word.replace(/[,.:;'"“”‘’()&?-]/g, ''); // Hyphen either at the beginning or end, or escaped, i.e. \-
+        console.log(normalized);
         APIcalls.push(API(normalized));
       } else {
         APIcalls.push(new Promise((resolution) => {
+          console.log(word);
           resolution(word);
         }));
       }
@@ -82,17 +84,21 @@ const parse = (text, options) =>
     Promise.all(APIcalls)
       .then((data) => {
         const rip = data.map((response) => {
-          const { pronunciation } = response;
-          if (pronunciation && typeof pronunciation === 'object' && 'all' in pronunciation) {
-            return pronunciation.all;
-          } else if (pronunciation && (typeof pronunciation === 'object' && ('noun' in pronunciation || 'verb' in pronunciation))) {
-            return (pronunciation.noun ? pronunciation.noun : '').concat(' '.concat(pronunciation.verb ? pronunciation.verb : ''));
-          } else if (typeof pronunciation === 'string') {
-            return pronunciation;
-          } else if ('message' in response) {
-            return response;
+          try {
+            const { pronunciation } = response;
+            if (pronunciation && typeof pronunciation === 'object' && 'all' in pronunciation) {
+              return pronunciation.all;
+            } else if (pronunciation && (typeof pronunciation === 'object' && ('noun' in pronunciation || 'verb' in pronunciation))) {
+              return (pronunciation.noun ? pronunciation.noun : '').concat(' '.concat(pronunciation.verb ? pronunciation.verb : ''));
+            } else if (typeof pronunciation === 'string') {
+              return pronunciation;
+            } else if ('message' in response) {
+              return response;
+            }
+            return fillString;
+          } catch (error) {
+            return fillString;
           }
-          return fillString;
         });
         let crayon = 0;
         let dirtyBrush = false;


### PR DESCRIPTION
1. Make homepage instructions clearer
2. Make composition text stateful (this restores on browser refresh)
3. Add error-handling for words that don't exist (maybe the API returns `undefined` if the word requested isn't a "real" word)
4. Make the `Strict` and `Loose` options more distinct
5. Fix the example-rap string